### PR TITLE
Docs: Update installation guide with PostGIS setup steps

### DIFF
--- a/website/docs/dev-documentation/install.md
+++ b/website/docs/dev-documentation/install.md
@@ -13,13 +13,14 @@ description: Installation instructions
 | 0.28            | coming soon |
 | 0.29            | coming soon |
 
-To install Decidim Geo, you need a [Posgis](https://postgis.net/) extension installed.
+## Prerequisites
+To install Decidim Geo, ensure you have the [PostGIS](https://postgis.net/) extension installed and enabled on your PostgreSQL database.
 
 ### Install Decidim Geo
 
 Add the gem to your Gemfile
 ```
-    gem "decidim-decidim_geo", version: "~> 0.2.6"
+  gem 'decidim-decidim_geo', '~> 0.2.1'
 ```
 
 Add javascripts libraries
@@ -29,7 +30,7 @@ Add javascripts libraries
 
 Copy migrations and migrate
 ``` 
-    bundle exec rails decidim_geo:migration:install
+    bundle exec rails decidim_geo:install:migrations
     bundle exec rails db:migrate
 ```
 
@@ -47,4 +48,32 @@ All migrations should be up
 Assets compilations should pass. 
 ``` 
     bundle exec rails assets:precompile
+```
+### Tips for Installing [PostGIS](https://postgis.net/)
+If you haven't installed PostGIS yet, follow these steps:
+
+```sh
+sudo apt update && sudo apt install postgis postgresql-14-postgis-3
+```
+Enable the PostGIS extension inside your PostgreSQL database:
+```sql
+CREATE EXTENSION postgis;
+```
+
+Modify your `docker-compose.yml` file to use PostGIS:
+```yaml
+pg:
+  image: postgis/postgis:latest
+  environment:
+    POSTGRES_PASSWORD: postgres
+Run the following command to add the required gem:
+```sh
+echo 'gem "activerecord-postgis-adapter"' >> Gemfile
+```
+
+Modify the file database.yml, changing the adapter to ``postgis``
+
+Then, install the dependencies:
+```sh
+bundle install
 ```


### PR DESCRIPTION
## Description  

Hello!  

I am a Software Engineering student at the University of Brasília, and while running Decidim Geo for a university project, we noticed that the installation guide was outdated. Some steps were missing, making it difficult to set up the project correctly.  

This PR introduces the following updates to the installation guide:  

- **Suggested addition:** A PostGIS setup section, including a `docker-compose.yml` example and the `activerecord-postgis-adapter` gem. While not strictly required, this setup was necessary in our case, and we believe it may help other users.  
- **Correction:** The documentation previously referenced version `0.2.6` of `decidim-decidim_geo`, but according to [RubyGems](https://rubygems.org/gems/decidim-decidim_geo/versions/0.2.1), the only available version is `0.2.1`. The guide has been updated accordingly.  

This project was coordinated by **Professor Renato Coral** in collaboration with the **LAPPIS Lab at the University of Brasília (UNB)**. These modifications reflect the steps we followed to get everything running properly, and we hope they will help other users facing similar issues.  

Looking forward to your feedback. 